### PR TITLE
Fix older python versions

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -207,11 +207,11 @@ def load_config(config: FanslyConfig) -> None:
         
         # Normal (Timeline & Messages), Timeline, Messages, Single (Single by post id) or Collections -> str
         download_mode = config._parser.get(options_section, 'download_mode', fallback='Normal')
-        config.download_mode = DownloadMode(download_mode.lower())
+        config.download_mode = DownloadMode(download_mode.upper())
 
         # Advanced, Simple -> str
         metadata_handling = config._parser.get(options_section, 'metadata_handling', fallback='Advanced')
-        config.metadata_handling = MetadataHandling(metadata_handling.lower())
+        config.metadata_handling = MetadataHandling(metadata_handling.upper())
 
         # Booleans
         config.download_media_previews = config._parser.getboolean(options_section, 'download_media_previews', fallback=True)

--- a/config/metadatahandling.py
+++ b/config/metadatahandling.py
@@ -1,7 +1,7 @@
 """Metadata Handling"""
 
-
-from enum import StrEnum, auto
+from strenum import StrEnum
+from enum import auto
 
 
 class MetadataHandling(StrEnum):

--- a/config/modes.py
+++ b/config/modes.py
@@ -1,7 +1,7 @@
 """Download Modes"""
 
-
-from enum import StrEnum, auto
+from strenum import StrEnum
+from enum import auto
 
 
 class DownloadMode(StrEnum):

--- a/download/types.py
+++ b/download/types.py
@@ -1,7 +1,7 @@
 """Download Types"""
 
-
-from enum import StrEnum, auto
+from strenum import StrEnum
+from enum import auto
 
 
 class DownloadType(StrEnum):

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pyffmpeg==2.4.2.18.1
 python-dateutil==2.8.2
 requests==2.31.0
 rich==13.7.0
+strenum==0.4.15


### PR DESCRIPTION
I had a hard time to get the code to run on the last ubuntu 22.04 lts versions, caused by the use of the newer StrEnum class. Using the extra package is easy and works just as well. Please consider merging this change.