### PR TITLE
Hotfix "magic return value" of map_args_to_config

### DIFF
--- a/config/args.py
+++ b/config/args.py
@@ -324,7 +324,7 @@ def check_attributes(
     )
 
 
-def map_args_to_config(args: argparse.Namespace, config: FanslyConfig) -> bool:
+def map_args_to_config(args: argparse.Namespace, config: FanslyConfig) -> None:
     """Maps command-line arguments to the configuration object of
     the current session.
     
@@ -332,15 +332,11 @@ def map_args_to_config(args: argparse.Namespace, config: FanslyConfig) -> bool:
         retrieved via argparse.
     :param FanslyConfig config: The program configuration to map the
         arguments to.
-
-    :return bool download_mode_set: Used to determine whether the
-        download mode has been specified with the command line.
     """
     if config.config_path is None:
         raise RuntimeError('Internal error mapping arguments - configuration path not set. Load the config first.')
 
     config_overridden = False
-    download_mode_set = False
     
     config.debug = args.debug
     
@@ -368,22 +364,22 @@ def map_args_to_config(args: argparse.Namespace, config: FanslyConfig) -> bool:
     if args.download_mode_normal:
         config.download_mode = DownloadMode.NORMAL
         config_overridden = True
-        download_mode_set = True
+        config.download_mode_set = True
 
     if args.download_mode_messages:
         config.download_mode = DownloadMode.MESSAGES
         config_overridden = True
-        download_mode_set = True
+        config.download_mode_set = True
 
     if args.download_mode_timeline:
         config.download_mode = DownloadMode.TIMELINE
         config_overridden = True
-        download_mode_set = True
+        config.download_mode_set = True
 
     if args.download_mode_collection:
         config.download_mode = DownloadMode.COLLECTION
         config_overridden = True
-        download_mode_set = True
+        config.download_mode_set = True
 
     if args.download_mode_single is not None:
         post_id = args.download_mode_single
@@ -397,7 +393,7 @@ def map_args_to_config(args: argparse.Namespace, config: FanslyConfig) -> bool:
 
         config.post_id = post_id
         config_overridden = True
-        download_mode_set = True
+        config.download_mode_set = True
 
     if args.metadata_handling is not None:
         handling = args.metadata_handling.strip().lower()
@@ -527,5 +523,3 @@ def map_args_to_config(args: argparse.Namespace, config: FanslyConfig) -> bool:
         )
         config.config_path = config.config_path.parent / 'config_args.ini'
         save_config_or_raise(config)
-
-    return download_mode_set

--- a/config/fanslyconfig.py
+++ b/config/fanslyconfig.py
@@ -42,6 +42,7 @@ class FanslyConfig(object):
     # Objects
     _parser = ConfigParser(interpolation=None)
     _api: Optional[FanslyApi] = None
+    download_mode_set: bool = False
 
     #endregion File-Independent
 

--- a/config/validation.py
+++ b/config/validation.py
@@ -439,17 +439,16 @@ def validate_adjust_download_directory(config: FanslyConfig) -> None:
         save_config_or_raise(config)
 
 
-def validate_adjust_download_mode(config: FanslyConfig, download_mode_set: bool) -> None:
+def validate_adjust_download_mode(config: FanslyConfig) -> None:
     """Validates the `download_mode` value from `config.ini`
     and adjusts it if desired.
 
     :param FanslyConfig config: The configuration to validate and correct.
-    :param bool download_mode_set: Indicates whether a download mode as been set using args
     """
     current_download_mode = config.download_mode.capitalize()
     print_info(f"The current download mode is set to '{current_download_mode}'.")
 
-    if config.interactive and not download_mode_set:
+    if config.interactive and not config.download_mode_set:
         done = False
         while not done:
             key_confirmation = input(
@@ -471,12 +470,11 @@ def validate_adjust_download_mode(config: FanslyConfig, download_mode_set: bool)
                 done = True
 
 
-def validate_adjust_config(config: FanslyConfig, download_mode_set: bool) -> None:
+def validate_adjust_config(config: FanslyConfig) -> None:
     """Validates all input values from `config.ini`
     and corrects them if possible.
 
     :param FanslyConfig config: The configuration to validate and correct.
-    :param bool download_mode_set: Indicates whether a download mode as been set using args
     """
     if not validate_creator_names(config):
         raise ConfigError('Configuration error - no valid creator name specified.')
@@ -491,4 +489,4 @@ def validate_adjust_config(config: FanslyConfig, download_mode_set: bool) -> Non
 
     validate_adjust_download_directory(config)
 
-    validate_adjust_download_mode(config, download_mode_set)  # don't prompt if download mode has specifically been set with args
+    validate_adjust_download_mode(config)  # don't prompt if download mode has specifically been set with args

--- a/fansly_downloader_ng.py
+++ b/fansly_downloader_ng.py
@@ -101,11 +101,11 @@ def main(config: FanslyConfig) -> int:
     # may overwrite config.ini settings later on during validation
     # when the config may be saved again.
     # Thus a separate config_args.ini will be used for the session.
-    download_mode_set = map_args_to_config(args, config)
+    map_args_to_config(args, config)
 
     self_update(config)
 
-    validate_adjust_config(config, download_mode_set)
+    validate_adjust_config(config)
 
     if config.user_names is None \
             or config.download_mode == DownloadMode.NOTSET:


### PR DESCRIPTION
Removes "magic return value" of map_args_to_config and adds config attribute instead. Mentioned in #60 

> I'll accept though I'm not so happy with the single "magic return value" of map_args_to_config; the intuition returning a bool would be "did the mapping fail or not?". For me, a later fix would be to move that into the config class maybe even as a computed property (method),