### PR TITLE
Handle rate-limits and improve API robustness

### DIFF
--- a/api/fansly.py
+++ b/api/fansly.py
@@ -160,8 +160,8 @@ class FanslyApi(object):
     def get_with_ngsw(
                 self,
                 url: str,
-                params: dict[str, str]={},
-                cookies: dict[str, str]={},
+                params: Optional[dict[str, str]]=None,
+                cookies: Optional[dict[str, str]]=None,
                 stream: bool=False,
                 add_fansly_headers: bool=True,
                 alternate_token: Optional[str]=None,
@@ -173,10 +173,13 @@ class FanslyApi(object):
 
         existing_params = get_flat_qs_dict(url)
 
+        safe_params = params or {}
+        safe_cookies = cookies or {}
+
         request_params = {
             **existing_params,
             **default_params,
-            **params,
+            **safe_params,
         }
 
         headers=self.get_http_headers(
@@ -185,7 +188,11 @@ class FanslyApi(object):
             alternate_token=alternate_token,
         )
 
-        self.cors_options_request(url)
+        try:
+            self.cors_options_request(url)
+        except requests.RequestException:
+            # Preflight failure is non-fatal for this CLI context.
+            pass
 
         (_, file_url) = split_url(url)
 
@@ -196,8 +203,8 @@ class FanslyApi(object):
             'stream': stream,
         }
 
-        if len(cookies) > 0:
-            arguments['cookies'] = cookies
+        if len(safe_cookies) > 0:
+            arguments['cookies'] = safe_cookies
 
         return self.http_session.get(**arguments)
 
@@ -268,7 +275,7 @@ class FanslyApi(object):
 
     def get_group(self) -> Response:
         return self.get_with_ngsw(
-            url='https://apiv3.fansly.com/api/v1/group',
+            url='https://apiv3.fansly.com/api/v1/messaging/groups',
         )
 
 
@@ -562,4 +569,4 @@ class FanslyApi(object):
 
         return self.device_id
 
-    #region
+    #endregion

--- a/download/account.py
+++ b/download/account.py
@@ -38,6 +38,32 @@ def get_creator_account_info(config: FanslyConfig, state: DownloadState) -> None
             raw_response = config.get_api() \
                 .get_creator_account_info(state.creator_name)
 
+            if raw_response.status_code != 200:
+                if raw_response.status_code == 401:
+                    message = \
+                        f"API returned unauthorized (24). " \
+                        f"This is most likely because of a wrong authorization " \
+                        f"token in the configuration file." \
+                        f"\n{21*' '}Have you surfed Fansly on this browser recently?" \
+                        f"\n{21*' '}Used authorization token: '{config.token}'" \
+                        f'\n  {raw_response.text}'
+
+                    raise ApiAuthenticationError(message)
+
+                if raw_response.status_code == 429:
+                    message = \
+                        'Fansly API rate-limit reached while getting account info (25). ' \
+                        'Please retry in a moment or increase delay settings.' \
+                        f'\n  {raw_response.text}'
+
+                    raise ApiError(message)
+
+                message = \
+                    'Bad response from fansly API (25). Please make sure your configuration file is not malformed.' \
+                    f'\n  status: {raw_response.status_code}\n  {raw_response.text}'
+
+                raise ApiError(message)
+
             account = raw_response.json()['response'][0]
 
             state.creator_id = account['id']

--- a/download/collections.py
+++ b/download/collections.py
@@ -3,11 +3,11 @@
 
 from .common import process_download_accessible_media
 from .downloadstate import DownloadState
+from .media import download_media_infos
 from .types import DownloadType
 
 from config import FanslyConfig
 from textio import input_enter_continue, print_error, print_info
-from utils.common import batch_list
 
 
 def download_collections(config: FanslyConfig, state: DownloadState):
@@ -26,29 +26,9 @@ def download_collections(config: FanslyConfig, state: DownloadState):
         collections = collections_response.json()
         account_media_orders = collections['response']['accountMediaOrders']
         account_media_ids = [order['accountMediaId'] for order in account_media_orders]
-  
-        # Splitting the list into batches and making separate API calls for each
-        for batch in batch_list(account_media_ids, config.BATCH_SIZE):
 
-            batched_ids = ','.join(batch)
-
-            media_info_response = config.get_api() \
-                .get_account_media(batched_ids)
-
-            if media_info_response.status_code == 200:
-                media_info = media_info_response.json()['response']
-    
-                process_download_accessible_media(config, state, media_info)
-            
-            else:
-                print_error(
-                    f"Media batch download failed. Response code: "
-                    f"{media_info_response.status_code}"
-                    f"\n{media_info_response.text}"
-                    f"\n\nAffected media IDs: {batched_ids}",
-                    23
-                )
-                input_enter_continue(config.interactive)
+        media_info = download_media_infos(config, account_media_ids)
+        process_download_accessible_media(config, state, media_info)
 
         if state.duplicate_count > 0 and config.show_downloads and not config.show_skipped_downloads:
             print_info(

--- a/download/media.py
+++ b/download/media.py
@@ -2,6 +2,9 @@
 
 
 import random
+import requests
+from email.utils import parsedate_to_datetime
+from datetime import datetime, timezone
 
 from rich.progress import Progress, BarColumn, TextColumn
 from rich.table import Column
@@ -20,43 +23,124 @@ from textio import print_info, print_warning
 from utils.common import batch_list
 
 
+def _get_retry_after_seconds(retry_after: str | None, fallback: float) -> float:
+    """Parses Retry-After header as seconds or HTTP date; returns fallback on failure."""
+    if retry_after is None:
+        return fallback
+
+    retry_after = retry_after.strip()
+
+    if retry_after.isdigit():
+        return float(max(1, int(retry_after)))
+
+    try:
+        retry_after_dt = parsedate_to_datetime(retry_after)
+
+        if retry_after_dt.tzinfo is None:
+            now = datetime.now()
+
+        else:
+            now = datetime.now(timezone.utc).astimezone(retry_after_dt.tzinfo)
+
+        delta_seconds = (retry_after_dt - now).total_seconds()
+        return float(max(1.0, delta_seconds))
+
+    except Exception:
+        return fallback
+
+
+def _fetch_single_batch(
+            config: FanslyConfig,
+            current_batch: list[str],
+            max_retries: int = 3,
+        ) -> list[dict]:
+    """Fetches media info for a single batch of IDs with retry/backoff on 429."""
+    media_ids_str = ','.join(current_batch)
+    results: list[dict] = []
+
+    for attempt in range(max_retries + 1):
+        try:
+            resp = config.get_api().get_account_media(media_ids_str)
+        except requests.exceptions.RequestException as ex:
+            # If the exception carries a 429 response, handle it below
+            resp = getattr(ex, 'response', None)
+            if resp is None or resp.status_code != 429:
+                raise
+            # fall through to the 429 handler
+
+        status = resp.status_code
+
+        if status == 200:
+            data = resp.json()
+            if not data.get('success'):
+                raise ApiError(
+                    f"Could not retrieve media info for {media_ids_str} "
+                    f"- API unsuccessful | content: \n{data}"
+                )
+            results.extend(data.get('response', []))
+            return results
+
+        if status == 429:
+            if attempt < max_retries:
+                retry_after = resp.headers.get('Retry-After')
+                wait = _get_retry_after_seconds(retry_after, 10.0)
+                wait += random.uniform(1.0, 3.0) + attempt * 2
+                print_warning(
+                    f"Rate-limited on media batch ({len(current_batch)} IDs). "
+                    f"Retry {attempt + 1}/{max_retries} in {wait:.1f}s ..."
+                )
+                sleep(wait)
+                continue
+            # Exhausted retries — caller will split
+            return []
+
+        # Any other non-200 status
+        raise DownloadError(
+            f"Could not retrieve media info for {media_ids_str} "
+            f"- status_code: {status} "
+            f"| content: \n{resp.content.decode('utf-8')}"
+        )
+
+    return []
+
+
 def download_media_infos(
             config: FanslyConfig,
             media_ids: list[str]
         ) -> list[dict]:
-
+    """Download media infos in batches, with 429 retry and adaptive splitting."""
     media_infos: list[dict] = []
 
-    for ids in batch_list(media_ids, config.BATCH_SIZE):
-        media_ids_str = ','.join(ids)
+    # Use smaller batches to reduce chance of 429
+    effective_batch_size = max(1, min(config.BATCH_SIZE, 50))
 
-        media_info_response = config.get_api() \
-            .get_account_media(media_ids_str)
+    for ids in batch_list(media_ids, effective_batch_size):
+        queue: list[list[str]] = [ids]
 
-        media_info_response.raise_for_status()
+        while queue:
+            batch = queue.pop(0)
+            result = _fetch_single_batch(config, batch, max_retries=3)
 
-        if media_info_response.status_code == 200:
-            media_info = media_info_response.json()
+            if result:
+                media_infos.extend(result)
+                # Slow down between successful batches
+                sleep(random.uniform(0.5, 1.0))
 
-            if not media_info['success']:
-                raise ApiError(
-                    f"Could not retrieve media info for {media_ids_str} due to an "
-                    f"API error - unsuccessful "
-                    f"| content: \n{media_info}"
+            elif len(batch) > 1:
+                # Split and retry with smaller chunks
+                mid = len(batch) // 2
+                queue.insert(0, batch[:mid])
+                queue.insert(1, batch[mid:])
+                print_warning(
+                    f"Splitting rate-limited batch of {len(batch)} "
+                    f"into {mid} + {len(batch) - mid} IDs."
                 )
+                sleep(random.uniform(2.0, 4.0))
 
-            for info in media_info['response']:
-                media_infos.append(info)
-
-        else:
-            raise DownloadError(
-                f"Could not retrieve media info for {media_ids_str} due to an "
-                f"error --> status_code: {media_info_response.status_code} "
-                f"| content: \n{media_info_response.content.decode('utf-8')}"
-            )
-
-        # Slow down a bit to be sure
-        sleep(random.uniform(0.4, 0.75))
+            else:
+                print_warning(
+                    f"Skipping media ID {batch[0]} - persistent rate-limit."
+                )
 
     return media_infos
 


### PR DESCRIPTION
fansly.py: Avoid mutable default args by using Optional[dict] and safe_* locals, add try/except around CORS preflight (non-fatal), use updated messaging groups endpoint, and fix region comment.

download/account.py: Add explicit response handling for creator info calls: raise ApiAuthenticationError on 401, ApiError on 429 or other non-200 responses, and include helpful debug text (including used token) in messages.

download/collections.py: Simplify collection media fetching by using the centralized download_media_infos helper instead of manual batched requests and error branches.

download/media.py: Implement robust batch media-info downloading with rate-limit handling: parse Retry-After (seconds or HTTP-date), _fetch_single_batch with retry/backoff on 429, adaptive splitting of batches when rate-limited, reduced effective batch size, and clearer error handling. Added imports for requests and date parsing. Overall changes aim to reduce 429 failures, provide clearer errors, and make API calls more resilient.